### PR TITLE
fix(load-engine): prefer to sort by wholesale discount

### DIFF
--- a/core/src/main/java/com/abavilla/fpi/load/repo/load/PromoSkuRepo.java
+++ b/core/src/main/java/com/abavilla/fpi/load/repo/load/PromoSkuRepo.java
@@ -62,7 +62,8 @@ public class PromoSkuRepo extends AbsMongoRepo<PromoSku> {
               ]
             }
             """,
-        Sort.ascending("type.ord", "offers.wholesaleDiscount"),
+        Sort.by("offers.wholesaleDiscount", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST)
+          .and("type.ord", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_LAST),
         telco.getValue(),
         keyword,
         NumberUtils.toInt(keyword)
@@ -98,7 +99,8 @@ public class PromoSkuRepo extends AbsMongoRepo<PromoSku> {
               ]
             }
             """,
-        Sort.ascending("type.ord", "offers.wholesaleDiscount"),
+      Sort.by("offers.wholesaleDiscount", Sort.Direction.Descending, Sort.NullPrecedence.NULLS_LAST)
+        .and("type.ord", Sort.Direction.Ascending, Sort.NullPrecedence.NULLS_LAST),
         keyword,
         NumberUtils.toInt(keyword)
     ).firstResultOptional();


### PR DESCRIPTION
Tweak load engine offer selection to prefer sorting by wholesale discount first before bundle type